### PR TITLE
PillContent in HeaderBar

### DIFF
--- a/app/(tabs)/assets.tsx
+++ b/app/(tabs)/assets.tsx
@@ -1,7 +1,7 @@
 import { Feather } from '@expo/vector-icons';
 import { View } from 'react-native';
 
-import HeaderBar from '~/components/HeaderBar';
+import { HeaderBar } from '~/components/HeaderBar';
 import FText from '~/components/Text/FText';
 import { Frame } from '~/components/Wrappers/Frame';
 

--- a/app/(tabs)/earn.tsx
+++ b/app/(tabs)/earn.tsx
@@ -1,7 +1,7 @@
 import { Feather } from '@expo/vector-icons';
 import { View } from 'react-native';
 
-import HeaderBar from '~/components/HeaderBar';
+import { HeaderBar } from '~/components/HeaderBar';
 import FText from '~/components/Text/FText';
 import { Frame } from '~/components/Wrappers/Frame';
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -6,7 +6,7 @@ import { View, ScrollView } from 'react-native';
 import { Button } from '~/components/Button';
 import Container from '~/components/Container';
 import CreateWalletButton from '~/components/CreateWalletButton';
-import HeaderBar from '~/components/HeaderBar';
+import { HeaderBar, PillMessageBox } from '~/components/HeaderBar';
 import Loading from '~/components/Loading';
 import TestModule from '~/components/TestModule';
 import FText from '~/components/Text/FText';
@@ -35,9 +35,19 @@ export default function Home() {
     return null;
   }
 
+  const homePillContent = () => {
+    return (
+      <PillMessageBox>
+        <FText className="!text-2xl" bold>
+          Good Morning!
+        </FText>
+      </PillMessageBox>
+    );
+  };
+
   return (
     <Frame>
-      <HeaderBar title="Home" />
+      <HeaderBar title="Home" pillContent={homePillContent} />
       <ScrollView>
         <FTitle className="text-4xl">Welcome to Fundamental!</FTitle>
         <FText className="text-lg">This is Fundamental</FText>

--- a/app/(tabs)/send.tsx
+++ b/app/(tabs)/send.tsx
@@ -1,7 +1,7 @@
 import { Feather } from '@expo/vector-icons';
 import { View } from 'react-native';
 
-import HeaderBar from '~/components/HeaderBar';
+import { HeaderBar } from '~/components/HeaderBar';
 import FText from '~/components/Text/FText';
 import { Frame } from '~/components/Wrappers/Frame';
 

--- a/app/(tabs)/trade.tsx
+++ b/app/(tabs)/trade.tsx
@@ -1,7 +1,7 @@
 import { Feather } from '@expo/vector-icons';
 import { View } from 'react-native';
 
-import HeaderBar from '~/components/HeaderBar';
+import { HeaderBar } from '~/components/HeaderBar';
 import FText from '~/components/Text/FText';
 import { Frame } from '~/components/Wrappers/Frame';
 

--- a/components/HeaderBar.tsx
+++ b/components/HeaderBar.tsx
@@ -1,32 +1,83 @@
 import { Feather } from '@expo/vector-icons';
 import { DrawerActions } from '@react-navigation/native';
 import { useNavigation } from 'expo-router';
+import { useState } from 'react';
 import { View, Image, TouchableOpacity } from 'react-native';
 
 import Title from './Text/FTitle';
 
 const fundy = require('../assets/fundy.png');
 
-const TitleBar = ({ title }: { title: string }) => {
+/**
+ * The Pill Message Box component is used to display text or other content when the user interacts with fundy through a visual comic book like bubble.
+ *
+ * @param {React.ReactNode} children - The content to be displayed inside the pill message box.
+ * @returns {JSX.Element} The pill message box frame with the children content inside.
+ */
+const PillMessageBox = ({ children }: { children: React.ReactNode }): JSX.Element => {
+  return (
+    <View className="relative rounded-xl border-2 border-primary bg-[rgba(135,32,254,0.5)] p-3">
+      <View className="absolute left-[325] top-[-13] border-b-[13px] border-l-[10px] border-r-[10px] border-b-[rgba(135,32,254,0.5)] border-l-transparent border-r-transparent" />
+      {children}
+    </View>
+  );
+};
+
+interface HeaderBarProps {
+  title: string;
+  pillContent?: () => React.ReactNode;
+}
+
+//* This typedoc comment is not right
+/**
+ * The HeaderBar component, displayed on top of every main page of the app.
+ *
+ * This component contains a menu button on the left side, a page title in the center,
+ * and an interactive "fundy" button on the right side that can toggle additional content.
+ * When the "fundy" button is pressed, it displays the provided content (if any) via the `pillContent` function.
+ *
+ * @param {string} title - The page title, displayed in the center of the header bar.
+ * @param {() => React.ReactNode} [pillContent] - A function that returns the content to be displayed when the user interacts with the "fundy" button.
+ *
+ * @returns {JSX.Element} The HeaderBar component.
+ *
+ * @example
+ * ```tsx
+ * <HeaderBar title="Dashboard" pillContent={() => <CustomComponent />} />
+ * ```
+ *
+ * @remarks
+ * - The component utilizes `useNavigation` to handle opening the drawer with the menu button.
+ * - `pillContent` is optional and is displayed only when the "fundy" button is clicked.
+ */
+const HeaderBar = ({ title, pillContent }: HeaderBarProps): JSX.Element => {
   const navigation = useNavigation();
 
   const openDrawer = () => {
     navigation.dispatch(DrawerActions.openDrawer());
   };
 
+  const [isPillOpened, setIsPillOpened] = useState(false);
+
+  const togglePill = () => setIsPillOpened(!isPillOpened);
+
   return (
-    <View className="h-50 z-10 flex-row items-center gap-2 py-4">
-      <TouchableOpacity onPress={openDrawer}>
-        <Feather name="menu" size={36} className="text-text" />
-      </TouchableOpacity>
-      <Title className="mt-2 text-4xl text-text">{title}</Title>
-      <Image
-        source={fundy}
-        style={{ marginLeft: 'auto', height: 64, width: 96 }}
-        resizeMode="contain"
-      />
+    <View className="flex flex-col">
+      <View className="h-50 z-10 flex-row items-center gap-2 py-4">
+        <TouchableOpacity onPress={openDrawer}>
+          <Feather name="menu" size={36} className="text-text" />
+        </TouchableOpacity>
+        <Title className="mt-2 text-4xl text-text">{title}</Title>
+        <TouchableOpacity onPress={togglePill} className="ml-auto">
+          <Image source={fundy} style={{ height: 64, width: 96 }} resizeMode="contain" />
+        </TouchableOpacity>
+      </View>
+      <View />
+      {isPillOpened && pillContent && (
+        <View className="relative mb-5">{pillContent && pillContent()}</View>
+      )}
     </View>
   );
 };
 
-export default TitleBar;
+export { HeaderBar, PillMessageBox };

--- a/components/HeaderBar.tsx
+++ b/components/HeaderBar.tsx
@@ -26,31 +26,38 @@ const PillMessageBox = ({ children }: { children: React.ReactNode }): JSX.Elemen
 interface HeaderBarProps {
   title: string;
   pillContent?: () => React.ReactNode;
+  pillMethod?: () => void;
 }
 
-//* This typedoc comment is not right
 /**
  * The HeaderBar component, displayed on top of every main page of the app.
  *
  * This component contains a menu button on the left side, a page title in the center,
  * and an interactive "fundy" button on the right side that can toggle additional content.
- * When the "fundy" button is pressed, it displays the provided content (if any) via the `pillContent` function.
+ * When the "fundy" button is pressed, it triggers the optional `pillMethod` function
+ * and displays the content provided by `pillContent`, if any.
  *
  * @param {string} title - The page title, displayed in the center of the header bar.
  * @param {() => React.ReactNode} [pillContent] - A function that returns the content to be displayed when the user interacts with the "fundy" button.
+ * @param {() => void} [pillMethod] - An optional callback function triggered when the "fundy" button is pressed.
  *
  * @returns {JSX.Element} The HeaderBar component.
  *
  * @example
  * ```tsx
- * <HeaderBar title="Dashboard" pillContent={() => <CustomComponent />} />
+ * <HeaderBar
+ *   title="Dashboard"
+ *   pillContent={() => <CustomComponent />}
+ *   pillMethod={() => alert("Pill toggled")}
+ * />
  * ```
  *
  * @remarks
  * - The component utilizes `useNavigation` to handle opening the drawer with the menu button.
  * - `pillContent` is optional and is displayed only when the "fundy" button is clicked.
+ * - `pillMethod`, if provided, is called each time the "fundy" button is clicked.
  */
-const HeaderBar = ({ title, pillContent }: HeaderBarProps): JSX.Element => {
+const HeaderBar = ({ title, pillContent, pillMethod }: HeaderBarProps): JSX.Element => {
   const navigation = useNavigation();
 
   const openDrawer = () => {
@@ -59,7 +66,10 @@ const HeaderBar = ({ title, pillContent }: HeaderBarProps): JSX.Element => {
 
   const [isPillOpened, setIsPillOpened] = useState(false);
 
-  const togglePill = () => setIsPillOpened(!isPillOpened);
+  const togglePill = () => {
+    pillMethod && pillMethod();
+    pillContent && setIsPillOpened(!isPillOpened);
+  };
 
   return (
     <View className="flex flex-col">

--- a/components/HeaderBar.tsx
+++ b/components/HeaderBar.tsx
@@ -1,8 +1,8 @@
 import { Feather } from '@expo/vector-icons';
 import { DrawerActions } from '@react-navigation/native';
 import { useNavigation } from 'expo-router';
-import { useState } from 'react';
-import { View, Image, TouchableOpacity } from 'react-native';
+import { useState, useRef } from 'react';
+import { View, Image, TouchableOpacity, Animated } from 'react-native';
 
 import Title from './Text/FTitle';
 
@@ -59,16 +59,26 @@ interface HeaderBarProps {
  */
 const HeaderBar = ({ title, pillContent, pillMethod }: HeaderBarProps): JSX.Element => {
   const navigation = useNavigation();
+  const [isPillOpened, setIsPillOpened] = useState(false);
 
   const openDrawer = () => {
     navigation.dispatch(DrawerActions.openDrawer());
   };
 
-  const [isPillOpened, setIsPillOpened] = useState(false);
+  const fadeAnim = useRef(new Animated.Value(0)).current;
 
   const togglePill = () => {
     pillMethod && pillMethod();
-    pillContent && setIsPillOpened(!isPillOpened);
+
+    if (pillContent) {
+      setIsPillOpened(!isPillOpened);
+
+      Animated.timing(fadeAnim, {
+        toValue: isPillOpened ? 0 : 1,
+        duration: 300,
+        useNativeDriver: true,
+      }).start();
+    }
   };
 
   return (
@@ -83,11 +93,50 @@ const HeaderBar = ({ title, pillContent, pillMethod }: HeaderBarProps): JSX.Elem
         </TouchableOpacity>
       </View>
       <View />
-      {isPillOpened && pillContent && (
-        <View className="relative mb-5">{pillContent && pillContent()}</View>
+      {pillContent && (
+        <Animated.View
+          style={{
+            opacity: fadeAnim,
+            marginBottom: 20,
+            position: 'relative',
+          }}>
+          {isPillOpened && pillContent()}
+        </Animated.View>
       )}
     </View>
   );
 };
+// const HeaderBar = ({ title, pillContent, pillMethod }: HeaderBarProps): JSX.Element => {
+//   const navigation = useNavigation();
+
+//   const openDrawer = () => {
+//     navigation.dispatch(DrawerActions.openDrawer());
+//   };
+
+//   const [isPillOpened, setIsPillOpened] = useState(false);
+
+//   const togglePill = () => {
+//     pillMethod && pillMethod();
+//     pillContent && setIsPillOpened(!isPillOpened);
+//   };
+
+//   return (
+//     <View className="flex flex-col">
+//       <View className="h-50 z-10 flex-row items-center gap-2 py-4">
+//         <TouchableOpacity onPress={openDrawer}>
+//           <Feather name="menu" size={36} className="text-text" />
+//         </TouchableOpacity>
+//         <Title className="mt-2 text-4xl text-text">{title}</Title>
+//         <TouchableOpacity onPress={togglePill} className="ml-auto">
+//           <Image source={fundy} style={{ height: 64, width: 96 }} resizeMode="contain" />
+//         </TouchableOpacity>
+//       </View>
+//       <View />
+//       {isPillOpened && pillContent && (
+//         <View className="relative mb-5">{pillContent && pillContent()}</View>
+//       )}
+//     </View>
+//   );
+// };
 
 export { HeaderBar, PillMessageBox };

--- a/components/TestModule.tsx
+++ b/components/TestModule.tsx
@@ -1,10 +1,8 @@
-import { useEmbeddedWallet, isNotCreated, usePrivy, getUserEmbeddedWallet, PrivyEmbeddedWalletProvider } from '@privy-io/expo';
+import { useEmbeddedWallet, isNotCreated, usePrivy } from '@privy-io/expo';
 import React from 'react';
-import { Alert, View } from 'react-native';
-import alchemy from '../Services/alchemyService';
-import signMessage from '~/Services/privyService';
-import { isConnected, needsRecovery } from '@privy-io/expo';
-import viem from '~/Services/viemService';
+import { View } from 'react-native';
+import alchemy from '~/services/alchemyService';
+import viem from '~/services/viemService';
 
 import { Button } from './Button';
 import Container from './Container';

--- a/components/Text/FText.tsx
+++ b/components/Text/FText.tsx
@@ -37,10 +37,7 @@ const FText = ({ children, className, italic, medium, bold, ...props }: TitlePro
   if (italic) font += '_Italic';
 
   return (
-    <Text
-      className={`${className} text-text`}
-      style={{ fontFamily: font, fontSize: 18 }}
-      {...props}>
+    <Text className={`${className} text-xl text-text`} style={{ fontFamily: font }} {...props}>
       {children}
     </Text>
   );


### PR DESCRIPTION
- adds a new `PillContent` prop to the `HeaderBar` component, allowing us to pass pretty much anything we want to it, triggering when the user interacts with the fundy logo
- to conveniently display simple text through this prop, I also added a `PillMessageBox` wrapper-like component that replicates a comic book like bubble
- also added a `pillMethod` prop that will trigger any method passed to the component when pressed