### PR TITLE
242 swap token value and usd value

### DIFF
--- a/components/Send/AmountInput.tsx
+++ b/components/Send/AmountInput.tsx
@@ -1,5 +1,5 @@
 import { Feather } from '@expo/vector-icons';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import {
   View,
   TextInput,
@@ -17,6 +17,7 @@ import { getTokenAmountPrice } from '~/utils/helpers/tokens/getTokenAmountPrice'
 import { getUserTokenAmount } from '~/utils/helpers/tokens/getUserTokenAmount';
 import { getUserTokenValue } from '~/utils/helpers/tokens/getUserTokenValue';
 import { printToken } from '~/utils/helpers/tokens/printToken';
+
 interface AmountInputProps {
   onChange: (value: string) => void;
   value: string;
@@ -39,17 +40,85 @@ export const AmountInput = ({
   title = 'Amount',
 }: AmountInputProps) => {
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [inputMode, setInputMode] = useState<'crypto' | 'fiat'>('crypto');
 
-  const handleInputChange = (value: string) => {
-    onChange(value.replace(/[^0-9.]/g, ''));
-  };
+  // Calculate price per token (USD)
+  const pricePerToken = useMemo(() => {
+    if (!selectedToken) return 0;
+    return getTokenAmountPrice(selectedToken.address, 1, tokens);
+  }, [selectedToken, tokens]);
+
+  // Calculate values for both modes
+  const cryptoValue = useMemo(() => {
+    if (inputMode === 'crypto') {
+      return value;
+    } else {
+      // Convert fiat to crypto
+      const v = parseFloat(value);
+      if (!pricePerToken || value.trim() === '' || isNaN(v)) return '';
+      return (v / pricePerToken).toString();
+    }
+  }, [value, inputMode, pricePerToken]);
+
+  const fiatValue = useMemo(() => {
+    if (inputMode === 'fiat') {
+      return value;
+    } else {
+      // Convert crypto to fiat
+      const v = parseFloat(value);
+      if (!pricePerToken || isNaN(v)) return '';
+      return (v * pricePerToken).toString();
+    }
+  }, [value, inputMode, pricePerToken]);
 
   const balanceDisplay =
     selectedToken && selectedTokenBalance
       ? getUserTokenAmount(selectedToken?.address, tokens, user)
       : 0;
 
-  const isValidAmount = value !== '' && !isNaN(Number(value)) && Number(value) <= balanceDisplay;
+  const maxFiat = (balanceDisplay * pricePerToken).toFixed(2);
+
+  const isValidAmount = useMemo(() => {
+    if (value === '' || isNaN(Number(value))) return false;
+    if (inputMode === 'crypto') {
+      return Number(value) <= balanceDisplay;
+    } else {
+      return Number(value) <= balanceDisplay * pricePerToken;
+    }
+  }, [value, inputMode, balanceDisplay, pricePerToken]);
+
+  const handleInputChange = (val: string) => {
+    const sanitizedValue = val.replace(/[^0-9.]/g, '');
+    const isValidNumber = /^(\d+(\.\d{0,})?)?$/.test(sanitizedValue);
+    if (isValidNumber) {
+      onChange(sanitizedValue);
+    }
+  };
+
+  const handleFiatToggle = () => {
+    // When toggling, convert the value to the other mode
+    if (inputMode === 'crypto') {
+      // Convert crypto to fiat
+      const v = parseFloat(value);
+      if (!pricePerToken || isNaN(v)) {
+        setInputMode('fiat');
+        onChange('');
+      } else {
+        setInputMode('fiat');
+        onChange((v * pricePerToken).toFixed(2));
+      }
+    } else {
+      // Convert fiat to crypto
+      const v = parseFloat(value);
+      if (!pricePerToken || isNaN(v)) {
+        setInputMode('crypto');
+        onChange('');
+      } else {
+        setInputMode('crypto');
+        onChange((v / pricePerToken).toString());
+      }
+    }
+  };
 
   const handleTokenSelect = (token: Token) => {
     setIsPickerOpen(false);
@@ -85,16 +154,20 @@ export const AmountInput = ({
           className={`flex-1 rounded-lg bg-content text-4xl font-semibold
             ${value === '' ? 'text-text' : isValidAmount ? 'text-text' : 'text-error'}`}
           keyboardType="numeric"
-          placeholder={`0 ${selectedToken?.symbol || ''}`}
+          placeholder={inputMode === 'crypto' ? `0 ${selectedToken?.symbol || ''}` : '$0.00'}
           value={value}
           onChangeText={handleInputChange}
           placeholderTextColor="#888"
         />
       </View>
       <View className="flex-row items-center justify-between">
-        <FText className="!text-neutral" bold>
-          ≈${getTokenAmountPrice(selectedToken?.address || '', Number(value), tokens).toFixed(2)}
-        </FText>
+        <TouchableOpacity onPress={handleFiatToggle} activeOpacity={0.7}>
+          <FText className="!text-neutral" bold>
+            {inputMode === 'crypto'
+              ? `=$${Number(fiatValue).toFixed(2)}`
+              : `${Number(cryptoValue).toPrecision(6)} ${selectedToken?.symbol || ''}`}
+          </FText>
+        </TouchableOpacity>
         <View className="flex-row items-center gap-2">
           <FText className="!text-lg text-text" bold>
             {printToken(balanceDisplay, selectedToken ? selectedToken : undefined)}
@@ -102,11 +175,15 @@ export const AmountInput = ({
           </FText>
           <TouchableOpacity
             className="rounded-xl bg-primary px-2"
-            onPress={() =>
-              onChange(
-                printToken(balanceDisplay, selectedToken ? selectedToken : undefined).toString()
-              )
-            }>
+            onPress={() => {
+              if (inputMode === 'crypto') {
+                onChange(
+                  printToken(balanceDisplay, selectedToken ? selectedToken : undefined).toString()
+                );
+              } else {
+                onChange(maxFiat.toString());
+              }
+            }}>
             <FText className="text-white" bold>
               Max
             </FText>
@@ -150,7 +227,7 @@ export const AmountInput = ({
                 }}
               />
               <TouchableOpacity
-                className="w-full items-center rounded-lg"
+                className="w-full items-center rounded-lg bg-primary py-3"
                 onPress={() => setIsPickerOpen(false)}>
                 <FText className="text-lg text-text" bold>
                   Close

--- a/components/Send/AmountInput.tsx
+++ b/components/Send/AmountInput.tsx
@@ -227,7 +227,7 @@ export const AmountInput = ({
                 }}
               />
               <TouchableOpacity
-                className="w-full items-center rounded-lg bg-primary py-3"
+                className="w-full items-center rounded-lg"
                 onPress={() => setIsPickerOpen(false)}>
                 <FText className="text-lg text-text" bold>
                   Close

--- a/components/Trade/ConfirmTradeModal.tsx
+++ b/components/Trade/ConfirmTradeModal.tsx
@@ -89,7 +89,7 @@ export const ConfirmTradeModal = ({
                       {selectedPayToken.symbol}
                     </FText>
                     <FText className="!text-neutral" bold>
-                      ≈$
+                      =$
                       {printToken(
                         getTokenAmountPrice(
                           selectedPayToken.address || '',
@@ -121,7 +121,7 @@ export const ConfirmTradeModal = ({
                       {selectedGetToken.symbol}
                     </FText>
                     <FText className="!text-neutral" bold>
-                      ≈$
+                      =$
                       {getTokenAmountPrice(
                         selectedGetToken.address || '',
                         digitsToAmount(Number(quote.buyAmount), selectedGetToken!),

--- a/components/Trade/QuoteDisplay.tsx
+++ b/components/Trade/QuoteDisplay.tsx
@@ -127,7 +127,7 @@ export const QuoteDisplay = ({
         </FText>
       </View>
       <FText className="!text-neutral" bold>
-        ≈${getTokenAmountPrice(selectedToken?.address || '', Number(quoteValue), tokens).toFixed(2)}
+        =${getTokenAmountPrice(selectedToken?.address || '', Number(quoteValue), tokens).toFixed(2)}
       </FText>
       <Modal visible={isPickerOpen} transparent animationType="fade">
         <TouchableWithoutFeedback onPress={() => setIsPickerOpen(false)}>


### PR DESCRIPTION
This pull request introduces significant enhancements to the `AmountInput` component by adding support for toggling between cryptocurrency and fiat input modes.

### Enhancements to `AmountInput` Component:

* Introduced a new `inputMode` state (`'crypto' | 'fiat'`) to allow users to toggle between entering values in cryptocurrency or fiat. Added a `handleFiatToggle` method to switch modes while converting the value appropriately.
* Implemented `useMemo` hooks to calculate `cryptoValue`, `fiatValue`, and `pricePerToken` dynamically based on the selected token and input mode, optimizing performance.
* Updated the `isValidAmount` logic to validate inputs contextually based on the active mode and token balance.
* Modified the placeholder text and display logic to reflect the active input mode (`crypto` or `fiat`) and updated the "Max" button functionality to handle both modes.

### Minor Updates to Other Components:

* Replaced the `≈ prefix with `= in `ConfirmTradeModal` and `QuoteDisplay` components to standardize the display of fiat values. [[1]](diffhunk://#diff-46181c93ee46bc7142c080769924802754d3187db68f4e4a184f9109a20214a8L92-R92) [[2]](diffhunk://#diff-46181c93ee46bc7142c080769924802754d3187db68f4e4a184f9109a20214a8L124-R124) [[3]](diffhunk://#diff-cf4a36721edf00987b28333676577744837147e44e2af3698857f69abe76719eL130-R130) 

These changes improve the user experience by providing more flexibility in specifying amounts and ensuring consistent formatting across components.