### PR TITLE
add: ens check in subname

### DIFF
--- a/components/Profile/RegisterENS.tsx
+++ b/components/Profile/RegisterENS.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { View } from 'react-native';
 import Toast from 'react-native-toast-message';
 
@@ -8,8 +8,9 @@ import { TextInputField } from '../TextInputField';
 import { useAppData } from '../Wrappers/AppData';
 
 import { updateENS } from '~/services/Supabase/updateENS';
-import { registerName } from '~/services/viemService';
+import { registerName, isENSNameAvailable } from '~/services/viemService';
 import { toastConfig } from '~/utils/toastConfig';
+import { debounce } from '~/utils/helpers/debounce';
 
 // Check if the subname is valid and available
 // TODO: Check if the subname is available
@@ -26,6 +27,9 @@ const isValidSubname = (subname: string) => {
 export const RegisterENS = () => {
   const { privy, user } = useAppData();
   const [subname, setSubname] = useState('');
+  const [isAvailable, setIsAvailable] = useState<boolean | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [hasInteracted, setHasInteracted] = useState(false);
   const address = privy.wallet?.account?.address || '';
 
   if (!privy.wallet || privy.wallet.status !== 'connected') {
@@ -37,6 +41,31 @@ export const RegisterENS = () => {
   }
 
   const provider = privy.wallet.provider;
+
+  // Debounced ENS availability check
+  const checkAvailability = debounce(async (name: string) => {
+    setChecking(true);
+    if (isValidSubname(name)) {
+      try {
+        const available = await isENSNameAvailable(`${name}.fdmntl.eth`);
+        setIsAvailable(available);
+      } catch (error) {
+        setIsAvailable(null);
+      }
+    } else {
+      setIsAvailable(null);
+    }
+    setChecking(false);
+  }, 500);
+
+  // Watch subname changes
+  useEffect(() => {
+    if (subname.trim()) {
+      checkAvailability(subname);
+    } else {
+      setIsAvailable(null);
+    }
+  }, [subname]);
 
   return (
     <View className="flex gap-2">
@@ -50,18 +79,45 @@ export const RegisterENS = () => {
           value={subname}
           onChange={(value) => {
             setSubname(value);
+            if (!hasInteracted) setHasInteracted(true);
           }}
-          isValid={isValidSubname(subname)}
+          isValid={isValidSubname(subname) && isAvailable !== false}
         />
         <FText className="pt-[2px] !text-xl" bold>
           .fdmntl.eth
         </FText>
       </View>
+      {/* ENS availability feedback */}
+      <View className="min-h-[24px] flex-row items-center gap-2">
+        {hasInteracted &&
+          (checking ? (
+            <FText className="!text-neutral" bold>
+              Checking availability...
+            </FText>
+          ) : !subname ? (
+            <FText className="!text-error" bold>
+              ENS cannot be empty
+            </FText>
+          ) : !isValidSubname(subname) ? (
+            <FText className="!text-error" bold>
+              Enter a valid ENS name
+            </FText>
+          ) : isAvailable === false ? (
+            <FText className="!text-error" bold>
+              Name is already taken
+            </FText>
+          ) : isAvailable === true ? (
+            <FText className="!text-success" bold>
+              Name is available
+            </FText>
+          ) : null)}
+      </View>
       <Button
         title="Register"
         className="mx-auto w-[150px]"
+        disabled={!subname || !isValidSubname(subname) || isAvailable === false || checking}
         onPress={async () => {
-          if (isValidSubname(subname)) {
+          if (isValidSubname(subname) && isAvailable) {
             try {
               await registerName(provider, subname, address as `0x${string}`);
               updateENS(user.id, subname);
@@ -84,7 +140,8 @@ export const RegisterENS = () => {
             Toast.show({
               type: 'error',
               text1: 'Invalid ENS',
-              text2: 'Please enter a valid ENS name.',
+              text2:
+                isAvailable === false ? 'Name is already taken.' : 'Please enter a valid ENS name.',
               ...toastConfig,
             });
           }

--- a/components/Profile/RegisterENS.tsx
+++ b/components/Profile/RegisterENS.tsx
@@ -115,7 +115,7 @@ export const RegisterENS = () => {
       <Button
         title="Register"
         className="mx-auto w-[150px]"
-        disabled={!subname || !isValidSubname(subname) || isAvailable === false || checking}
+        disabled={!subname || !isValidSubname(subname) || isAvailable !== true || checking}
         onPress={async () => {
           if (isValidSubname(subname) && isAvailable) {
             try {

--- a/services/viemService.ts
+++ b/services/viemService.ts
@@ -311,3 +311,20 @@ export const resolveENS = async (ensName: string) => {
     throw new Error('Failed to resolve ENS domain');
   }
 };
+
+// Checks if an ENS name is available (not taken)
+export const isENSNameAvailable = async (ensName: string): Promise<boolean> => {
+  try {
+    const publicClient = createPublicClient({
+      chain: mainnet,
+      transport: http(),
+    });
+    const address = await publicClient.getEnsAddress({ name: ensName });
+    // If address is null, the ENS name is available
+    return address === null;
+  } catch (error) {
+    console.error('Error checking ENS name availability:', error);
+    // If there's an error, assume not available to be safe
+    return false;
+  }
+};


### PR DESCRIPTION
This pull request introduces an ENS name availability check to the `RegisterENS` component, enhancing the user experience by providing real-time feedback on the validity and availability of ENS names. Key changes include integrating a debounced availability check, updating the UI for feedback, and adding a new utility function to check ENS name availability.

### Enhancements to ENS name registration:

* **Debounced ENS availability check:** Added a `debounce` utility to reduce the frequency of availability checks when the user types, improving performance. The new `checkAvailability` function validates the subname and checks its availability asynchronously. (`components/Profile/RegisterENS.tsx`, [components/Profile/RegisterENS.tsxR45-R69](diffhunk://#diff-9002721dec7ba8067d944d580a216632904a05e5c103630c0850d8ec18d38197R45-R69))
* **Real-time feedback on ENS name status:** Updated the UI to provide immediate feedback on ENS name validity and availability, including messages for empty input, invalid names, and name availability status. (`components/Profile/RegisterENS.tsx`, [components/Profile/RegisterENS.tsxR82-R120](diffhunk://#diff-9002721dec7ba8067d944d580a216632904a05e5c103630c0850d8ec18d38197R82-R120))

### Backend support for ENS availability:

* **New utility function:** Added `isENSNameAvailable` in `viemService.ts` to check if an ENS name is already taken by querying the ENS registry. Handles errors gracefully by defaulting to "not available" for safety. (`services/viemService.ts`, [services/viemService.tsR314-R330](diffhunk://#diff-5079b022a67c94c94d59d7d07fdf9d9d33af56c79d8217a7d9e98b6b68a6800fR314-R330))